### PR TITLE
Implemented lock inside of the loop.

### DIFF
--- a/state_change_block.py
+++ b/state_change_block.py
@@ -4,6 +4,7 @@ from nio.common.signal.base import Signal
 from nio.metadata.properties.expression import ExpressionProperty
 from nio.metadata.properties.timedelta import TimeDeltaProperty
 from nio.modules.scheduler import Job
+from nio.modules.threading import Lock
 
 
 @Discoverable(DiscoverableType.block)
@@ -28,7 +29,9 @@ class StateChange(Block):
     def __init__(self):
         super().__init__()
         self._state = None
+        self._prev_state = None
         self._backup_job = None
+        self._lock = Lock()
 
     def configure(self, context):
         super().configure(context)
@@ -48,20 +51,22 @@ class StateChange(Block):
 
     def process_signals(self, signals):
         for signal in signals:
-            try:
-                prev_state = self._state
-                self._state = self.state_expr(signal)
-            except Exception as e:
-                self._logger.error("State Change failed: {}".format(str(e)))
-                self._state = prev_state
-            if prev_state is not None and self._state != prev_state:
-                # notify signal if there was a prev_state and
-                # the state has changed.
-                signal = Signal({
-                    "state": self._state,
-                    "prev_state": prev_state
-                })
-                self.notify_signals([signal])
+            with self._lock: # we need to make sure that the global variable doesn't change here
+                try:
+                    prev_state = self._state
+                    self._state = self.state_expr(signal)
+                    state = self._state
+                except Exception as e:
+                    self._logger.error("State Change failed: {}".format(str(e)))
+                    continue
+                if prev_state is not None and state != prev_state:
+                    # notify signal if there was a prev_state and
+                    # the state has changed.
+                    signal = Signal({
+                        "state": state,
+                        "prev_state": prev_state
+                    })
+                    self.notify_signals([signal])
 
     def _backup(self):
         ''' Persist the current state using the persistence module.


### PR DESCRIPTION
- This successfully prevented there from being duplicate state changes
  (i.e. sending signaals of True, True, True...
- However, with the 10k locked simulator the behavior is still erratic
- Therefore this change should be made no matter what, but we should also make the locking block
